### PR TITLE
Check for varnishncsa, not varnishlog when reloading varnishncsa

### DIFF
--- a/varnish.logrotate
+++ b/varnish.logrotate
@@ -22,7 +22,7 @@
   missingok
   postrotate
     if [ -d /run/systemd/system ]; then
-       systemctl -q is-active varnishlog.service || exit 0
+       systemctl -q is-active varnishncsa.service || exit 0
     fi
     /usr/sbin/invoke-rc.d varnishncsa reload > /dev/null
   endscript


### PR DESCRIPTION
Due to a cut and paste error we checked for varnishlog, rather than
varnishncsa before reloading varnishncsa.